### PR TITLE
(MAINT) Add a guard clause to stop relabelling

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -18,6 +18,9 @@ jobs:
 
       - uses: actions/checkout@v3
 
+      - name: Build 
+        run: npm run build
+
       - uses: ./
         name: Label issue or pull request
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -97,3 +97,5 @@ Thumbs.db
 # Ignore built ts files
 __tests__/runner/*
 lib/**/*
+
+dist

--- a/src/main.ts
+++ b/src/main.ts
@@ -15,6 +15,11 @@ export async function run(): Promise<void> {
 
     const client = new GitHubClient(token)
 
+    if (client.hasLabel(labelName)) {
+      core.info(`The '${labelName}' label is already present on this issue! 🙌`)
+      return
+    }
+
     if (
       !(await client.checkOrgMembership(orgs)) &&
       !client.isExcludedLogin(loginsToIgnore)


### PR DESCRIPTION
Prior to this PR  in some limited cases, it would be possible to trigger the action on an issue or PR that already has the specified label assigned. This is messy and would cause unnecessary notifications for watchers and contributors of the repository.

This PR adds hasLabel method to check whether the current issue already has the specified label applied. If true the action will return gracefully. If false the action will continue to label the issue or PR.